### PR TITLE
Disable webkit separately from gtk integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if (WIN32)
     nuget_add_webview(lib_webview)
     nuget_add_winrt(lib_webview)
 elseif (LINUX)
-    if (NOT DESKTOP_APP_DISABLE_GTK_INTEGRATION)
+    if (NOT DESKTOP_APP_DISABLE_WEBKITGTK)
         find_package(PkgConfig REQUIRED)
 
         if (DESKTOP_APP_USE_PACKAGED AND NOT DESKTOP_APP_USE_PACKAGED_LAZY)

--- a/webview/platform/linux/webview_linux.cpp
+++ b/webview/platform/linux/webview_linux.cpp
@@ -11,14 +11,14 @@
 namespace Webview {
 
 Available Availability() {
-#ifndef DESKTOP_APP_DISABLE_GTK_INTEGRATION
+#ifndef DESKTOP_APP_DISABLE_WEBKITGTK
 	return WebKit2Gtk::Availability();
-#else // !DESKTOP_APP_DISABLE_GTK_INTEGRATION
+#else // !DESKTOP_APP_DISABLE_WEBKITGTK
 	return Available{
 		.error = Available::Error::NoGtkOrWebkit2Gtk,
 		.details = "This feature was disabled at build time.",
 	};
-#endif // DESKTOP_APP_DISABLE_GTK_INTEGRATION
+#endif // DESKTOP_APP_DISABLE_WEBKITGTK
 }
 
 bool SupportsEmbedAfterCreate() {
@@ -26,11 +26,11 @@ bool SupportsEmbedAfterCreate() {
 }
 
 std::unique_ptr<Interface> CreateInstance(Config config) {
-#ifndef DESKTOP_APP_DISABLE_GTK_INTEGRATION
+#ifndef DESKTOP_APP_DISABLE_WEBKITGTK
 	return WebKit2Gtk::CreateInstance(std::move(config));
-#else // !DESKTOP_APP_DISABLE_GTK_INTEGRATION
+#else // !DESKTOP_APP_DISABLE_WEBKITGTK
 	return nullptr;
-#endif // DESKTOP_APP_DISABLE_GTK_INTEGRATION
+#endif // DESKTOP_APP_DISABLE_WEBKITGTK
 }
 
 } // namespace Webview

--- a/webview/platform/linux/webview_linux_webkit_gtk.cpp
+++ b/webview/platform/linux/webview_linux_webkit_gtk.cpp
@@ -7,7 +7,7 @@
 #include "webview/platform/linux/webview_linux_webkit_gtk.h"
 
 #ifdef DESKTOP_APP_DISABLE_GTK_INTEGRATION
-#error "WebKitGtk support depends on GTK integration."
+#error "WebKitGTK support depends on GTK integration."
 #endif // DESKTOP_APP_DISABLE_GTK_INTEGRATION
 
 #include "base/platform/linux/base_linux_gtk_integration.h"

--- a/webview/platform/linux/webview_linux_webkit_gtk.cpp
+++ b/webview/platform/linux/webview_linux_webkit_gtk.cpp
@@ -6,6 +6,10 @@
 //
 #include "webview/platform/linux/webview_linux_webkit_gtk.h"
 
+#ifdef DESKTOP_APP_DISABLE_GTK_INTEGRATION
+#error "WebKitGtk support depends on GTK integration."
+#endif // DESKTOP_APP_DISABLE_GTK_INTEGRATION
+
 #include "base/platform/linux/base_linux_gtk_integration.h"
 #include "base/platform/linux/base_linux_gtk_integration_p.h"
 


### PR DESCRIPTION
Depends on https://github.com/desktop-app/cmake_helpers/pull/91

This allows us to disable webkit without sacrificing the other features of the GTK integration.
