### PR TITLE
webview_linux_webkit_gtk.h: there are already exists extern C in the included headers

### DIFF
--- a/webview/platform/linux/webview_linux_webkit_gtk.h
+++ b/webview/platform/linux/webview_linux_webkit_gtk.h
@@ -6,11 +6,9 @@
 //
 #pragma once
 
-extern "C" {
 #include <JavaScriptCore/JavaScript.h>
 #include <gtk/gtk.h>
 #include <webkit2/webkit2.h>
-} // extern "C"
 
 namespace Webview::WebkitGtk {
 


### PR DESCRIPTION
Since  glib 2.68 C++ headers is included from glib headers:
```
#if defined(glib_typeof_2_68) && GLIB_VERSION_MIN_REQUIRED >= GLIB_VERSION_2_68
/* for glib_typeof */
#include <type_traits>
#endif
```

With telegram 2.8.6 I got

```
 2598 |   template<typename _Default, template<typename...> class _Op,
      |   ^~~~~~~~
In file included from /tmp/.private/lav/RPM/BUILD/telegram-desktop-2.8.6/Telegram/lib_webview/webview/platform/linux/webview_linux_webkit_gtk.cpp:7:
/tmp/.private/lav/RPM/BUILD/telegram-desktop-2.8.6/Telegram/lib_webview/webview/platform/linux/webview_linux_webkit_gtk.h:9:1: note: ‘extern "C"’ linkage started here
    9 | extern "C" {
      | ^~~~~~~~~~
In file included from /usr/include/glib-2.0/glib/gatomic.h:31,
                 from /usr/include/glib-2.0/glib/gthread.h:32,
                 from /usr/include/glib-2.0/glib/gasyncqueue.h:32,
                 from /usr/include/glib-2.0/glib.h:32,
                 from /usr/include/gtk-3.0/gdk/gdkconfig.h:13,
                 from /usr/include/gtk-3.0/gdk/gdk.h:30,
                 from /usr/include/gtk-3.0/gtk/gtk.h:30,
                 from /tmp/.private/lav/RPM/BUILD/telegram-desktop-2.8.6/Telegram/lib_webview/webview/platform/linux/webview_linux_webkit_gtk.h:11,
                 from /tmp/.private/lav/RPM/BUILD/telegram-desktop-2.8.6/Telegram/lib_webview/webview/platform/linux/webview_linux_webkit_gtk.cpp:7:
/usr/include/c++/10/type_traits:2603:3: error: template with C linkage

```