### PR TITLE
Try to destroy the compositor widget

### DIFF
--- a/webview/platform/linux/webview_linux_webkitgtk.cpp
+++ b/webview/platform/linux/webview_linux_webkitgtk.cpp
@@ -802,10 +802,7 @@ void Instance::startProcess() {
 			Gio::DBusConnection,
 			bool remotePeerVanished,
 			GLib::Error error) {
-		if (_compositorWidget) {
-			_compositorWidget->hide();
-		}
-		// TODO: Signal this further to cross-platform code somehow
+		_compositorWidget = nullptr;
 	}));
 
 	const auto started = _helper.signal_started().connect([&](Helper) {

--- a/webview/webview_embed.cpp
+++ b/webview/webview_embed.cpp
@@ -73,13 +73,13 @@ Window::Window(QWidget *parent, WindowConfig config)
 	if (!createWebView(parent, config) || !finishWebviewEmbedding()) {
 		return;
 	}
-	_webview->resizeToWindow();
 	base::install_event_filter(_widget, [=](not_null<QEvent*> e) {
 		if (e->type() == QEvent::Resize || e->type() == QEvent::Move) {
 			InvokeQueued(_widget.get(), [=] { _webview->resizeToWindow(); });
 		}
 		return base::EventFilterResult::Continue;
 	});
+	_webview->resizeToWindow();
 	setDialogHandler(nullptr);
 }
 


### PR DESCRIPTION
This should send QObject::destroyed that could be listened from cross-platform code