### PR TITLE
Clear nested compositor reference in stopProcess

### DIFF
--- a/webview/platform/linux/webview_linux_webkitgtk.cpp
+++ b/webview/platform/linux/webview_linux_webkitgtk.cpp
@@ -893,6 +893,7 @@ void Instance::stopProcess() {
 			compositor->deleteLater();
 		}
 	});
+	_compositor = nullptr;
 }
 
 void Instance::updateHistoryStates() {


### PR DESCRIPTION
This ensures the compositor will be spawned again in startProcess