### PR TITLE
Fix build error for GCC 14

### DIFF
--- a/webview/platform/linux/webview_linux_webkitgtk.cpp
+++ b/webview/platform/linux/webview_linux_webkitgtk.cpp
@@ -730,9 +730,11 @@ auto Instance::navigationHistoryState()
 
 void Instance::setOpaqueBg(QColor opaqueBg) {
 	if (_remoting) {
+#ifdef DESKTOP_APP_WEBVIEW_WAYLAND_COMPOSITOR
 		if (const auto widget = qobject_cast<QQuickWidget*>(_widget.get())) {
 			widget->setClearColor(opaqueBg);
 		}
+#endif // DESKTOP_APP_WEBVIEW_WAYLAND_COMPOSITOR
 
 		if (!_helper) {
 			return;


### PR DESCRIPTION
This file uses QQuickWidget unconditionally, so we must always include the header. GCC 14 by default rejects undefined references to classes.