### PR TITLE
Fix a use-after-free with gtk4

### DIFF
--- a/webview/platform/linux/webview_linux_webkitgtk.cpp
+++ b/webview/platform/linux/webview_linux_webkitgtk.cpp
@@ -175,16 +175,6 @@ Instance::~Instance() {
 	if (_backgroundProvider) {
 		g_object_unref(_backgroundProvider);
 	}
-	if (_webview) {
-		if (!gtk_widget_destroy) {
-			g_object_unref(_webview);
-		} else {
-			gtk_widget_destroy(GTK_WIDGET(_webview));
-		}
-	}
-	if (_x11SizeFix) {
-		gtk_widget_destroy(_x11SizeFix);
-	}
 	if (_window) {
 		if (gtk_window_destroy) {
 			gtk_window_destroy(GTK_WINDOW(_window));


### PR DESCRIPTION
The widgets are GInitiallyUnowned and get automatically destructed with the toplevel