### PR TITLE
Give Wayland compositor time to announce virtual output properties

### DIFF
--- a/webview/platform/linux/webview_linux_webkitgtk.cpp
+++ b/webview/platform/linux/webview_linux_webkitgtk.cpp
@@ -229,6 +229,11 @@ bool Instance::create(Config config) {
 			}
 			widget->setClearColor(config.opaqueBg);
 			widget->show();
+			const auto since = crl::now();
+			while (crl::now() - since < 1000) {
+				_compositor->processWaylandEvents();
+				GLib::MainContext::default_().iteration(false);
+			}
 		}
 #else // DESKTOP_APP_WEBVIEW_WAYLAND_COMPOSITOR
 		if (_compositor) {


### PR DESCRIPTION
This seem to fix gtk not following scale factor