### PR TITLE
Revert "Prevent redirect reply deletion on lambda copy"

### DIFF
--- a/webview/platform/linux/webview_linux_http_server.cpp
+++ b/webview/platform/linux/webview_linux_http_server.cpp
@@ -128,7 +128,7 @@ bool HttpServer::Private::processRedirect(
 	const auto reply = manager.get(request);
 	QObject::connect(reply, &QNetworkReply::finished, socket, [
 		=, 
-		replyGuard = std::make_unique<Guard>(crl::guard(reply, [=] {
+		replyGuard = gsl::finally(crl::guard(reply, [=] {
 			reply->deleteLater();
 		}))
 	] {


### PR DESCRIPTION
This reverts commit 79cfa80b1f404bd67bbe10f2d028dd35b5ca135f.

This didn't have any sense as gsl::final_action has copy constructor and operator deleted