### PR TITLE
Fix use-after-free in Wayland compositor output destruction

### DIFF
--- a/webview/platform/linux/webview_linux_compositor.cpp
+++ b/webview/platform/linux/webview_linux_compositor.cpp
@@ -27,9 +27,9 @@ struct Compositor::Private {
 	}
 
 	QPointer<QQuickWidget> widget;
-	base::unique_qptr<Output> output;
 	QWaylandXdgShell shell;
 	QWaylandXdgOutputManagerV1 xdgOutput;
+	base::unique_qptr<Output> output;
 	rpl::lifetime lifetime;
 };
 
@@ -291,6 +291,12 @@ Compositor::Compositor(const QByteArray &socketName)
 
 	setSocketName(socketName);
 	create();
+}
+
+Compositor::~Compositor() {
+	for (const auto output : outputs()) {
+		delete output;
+	}
 }
 
 void Compositor::setWidget(QQuickWidget *widget) {

--- a/webview/platform/linux/webview_linux_compositor.h
+++ b/webview/platform/linux/webview_linux_compositor.h
@@ -23,6 +23,7 @@ namespace Webview {
 class Compositor : public QWaylandQuickCompositor {
 public:
 	Compositor(const QByteArray &socketName = {});
+	~Compositor();
 
 	void setWidget(QQuickWidget *widget);
 


### PR DESCRIPTION
Outputs must be destroyed before XDG output manager