### PR TITLE
Allow third-party cookies when requested

### DIFF
--- a/webview/platform/linux/webview_linux_interface.xml
+++ b/webview/platform/linux/webview_linux_interface.xml
@@ -54,6 +54,7 @@
 			<arg type='i' name='marginBottom' direction='in'/>
 			<arg type='i' name='initialWidth' direction='in'/>
 			<arg type='i' name='initialHeight' direction='in'/>
+			<arg type='b' name='allowThirdPartyCookies' direction='in'/>
 		</method>
 		<method name='Reload'/>
 		<method name='Resolve'>

--- a/webview/platform/linux/webview_linux_webkitgtk.cpp
+++ b/webview/platform/linux/webview_linux_webkitgtk.cpp
@@ -79,6 +79,16 @@ void (* const SetGraphicsApi)(QSGRendererInterface::GraphicsApi) =
 
 std::string SocketPath;
 
+[[nodiscard]] bool AllowThirdPartyCookies(WebKitCookieManager *manager) {
+	if (!manager || !webkit_cookie_manager_set_accept_policy) {
+		return false;
+	}
+	webkit_cookie_manager_set_accept_policy(
+		manager,
+		WEBKIT_COOKIE_POLICY_ACCEPT_ALWAYS);
+	return true;
+}
+
 inline auto MethodError() {
 	return GLib::Error::new_literal(
 		Gio::DBusErrorNS_::quark(),
@@ -736,6 +746,7 @@ bool Instance::create(Config config) {
 		const auto shellMessageToken = _shellMessageToken;
 		const auto margins = config.windowMargins;
 		const auto initialSize = config.initialSize;
+		const auto allowThirdPartyCookies = config.allowThirdPartyCookies;
 		_helper.call_create(
 			debug,
 			r,
@@ -752,6 +763,7 @@ bool Instance::create(Config config) {
 			margins.bottom(),
 			initialSize.width(),
 			initialSize.height(),
+			allowThirdPartyCookies,
 			crl::guard(&guard, [&](
 					GObject::Object source_object,
 					Gio::AsyncResult res) {
@@ -881,6 +893,16 @@ bool Instance::create(Config config) {
 		WebKitNetworkSession *session = webkit_network_session_new(
 			baseData.c_str(),
 			baseCache.c_str());
+		if (config.allowThirdPartyCookies) {
+			const auto manager = webkit_network_session_get_cookie_manager
+				? webkit_network_session_get_cookie_manager(session)
+				: nullptr;
+			if (!AllowThirdPartyCookies(manager)) {
+				LOG(("WebView Error: Cookie policy API is unavailable."));
+				g_object_unref(session);
+				return false;
+			}
+		}
 		_webview = WEBKIT_WEB_VIEW(g_object_new(
 			WEBKIT_TYPE_WEB_VIEW,
 			"network-session",
@@ -892,6 +914,16 @@ bool Instance::create(Config config) {
 			"base-cache-directory", baseCache.c_str(),
 			"base-data-directory", baseData.c_str(),
 			nullptr);
+		if (config.allowThirdPartyCookies) {
+			const auto manager = webkit_website_data_manager_get_cookie_manager
+				? webkit_website_data_manager_get_cookie_manager(data)
+				: nullptr;
+			if (!AllowThirdPartyCookies(manager)) {
+				LOG(("WebView Error: Cookie policy API is unavailable."));
+				g_object_unref(data);
+				return false;
+			}
+		}
 		WebKitWebContext *context
 			= webkit_web_context_new_with_website_data_manager(data);
 		g_object_unref(data);
@@ -2793,11 +2825,13 @@ void Instance::registerHelperMethodHandlers() {
 			int marginTop,
 			int marginBottom,
 			int initialWidth,
-			int initialHeight) {
+			int initialHeight,
+			bool allowThirdPartyCookies) {
 		if (create({
 			.opaqueBg = QColor(r, g, b, a),
 			.userDataPath = path,
 			.debug = debug,
+			.allowThirdPartyCookies = allowThirdPartyCookies,
 			.mode = WindowMode(mode),
 			.windowStyle = WindowStyle(windowStyle),
 			.windowMargins = QMargins(

--- a/webview/platform/linux/webview_linux_webkitgtk_library.cpp
+++ b/webview/platform/linux/webview_linux_webkitgtk_library.cpp
@@ -106,6 +106,9 @@ ResolveResult Resolve(Platform platform, WindowMode mode) {
 	LOAD_LIBRARY_SYMBOL(lib, webkit_javascript_result_get_js_value);
 	LOAD_LIBRARY_SYMBOL(lib, webkit_website_data_manager_new);
 	LOAD_LIBRARY_SYMBOL(lib, webkit_web_context_new_with_website_data_manager);
+	LOAD_LIBRARY_SYMBOL(lib, webkit_network_session_get_cookie_manager);
+	LOAD_LIBRARY_SYMBOL(lib, webkit_website_data_manager_get_cookie_manager);
+	LOAD_LIBRARY_SYMBOL(lib, webkit_cookie_manager_set_accept_policy);
 	LOAD_LIBRARY_SYMBOL(lib, gtk_gesture_click_new);
 	LOAD_LIBRARY_SYMBOL(lib, gtk_event_controller_key_new);
 	LOAD_LIBRARY_SYMBOL(lib, gtk_event_controller_get_type);

--- a/webview/platform/linux/webview_linux_webkitgtk_library.h
+++ b/webview/platform/linux/webview_linux_webkitgtk_library.h
@@ -125,6 +125,7 @@ typedef struct _WebKitScriptDialog WebKitScriptDialog;
 typedef struct _WebKitWebsiteDataManager WebKitWebsiteDataManager;
 typedef struct _WebKitWebContext WebKitWebContext;
 typedef struct _WebKitNetworkSession WebKitNetworkSession;
+typedef struct _WebKitCookieManager WebKitCookieManager;
 typedef struct _WebKitAuthenticationRequest WebKitAuthenticationRequest;
 typedef struct _WebKitCredential WebKitCredential;
 typedef struct _WebKitPermissionRequest WebKitPermissionRequest;
@@ -205,6 +206,12 @@ typedef enum {
 	WEBKIT_CREDENTIAL_PERSISTENCE_FOR_SESSION,
 	WEBKIT_CREDENTIAL_PERSISTENCE_PERMANENT,
 } WebKitCredentialPersistence;
+
+typedef enum {
+	WEBKIT_COOKIE_POLICY_ACCEPT_ALWAYS,
+	WEBKIT_COOKIE_POLICY_ACCEPT_NEVER,
+	WEBKIT_COOKIE_POLICY_ACCEPT_NO_THIRD_PARTY,
+} WebKitCookieAcceptPolicy;
 
 namespace Webview::WebKitGTK::Library {
 
@@ -476,6 +483,13 @@ inline WebKitWebContext *(*webkit_web_context_new_with_website_data_manager)(
 inline WebKitNetworkSession *(*webkit_network_session_new)(
 	const char* data_directory,
 	const char* cache_directory);
+inline WebKitCookieManager *(*webkit_network_session_get_cookie_manager)(
+	WebKitNetworkSession *session);
+inline WebKitCookieManager *(*webkit_website_data_manager_get_cookie_manager)(
+	WebKitWebsiteDataManager *manager);
+inline void (*webkit_cookie_manager_set_accept_policy)(
+	WebKitCookieManager *cookie_manager,
+	WebKitCookieAcceptPolicy policy);
 inline void (*webkit_authentication_request_authenticate)(
 	WebKitAuthenticationRequest *request,
 	WebKitCredential *credential);

--- a/webview/webview_embed.cpp
+++ b/webview/webview_embed.cpp
@@ -71,6 +71,7 @@ bool Window::createWebView(QWidget *parent, const WindowConfig &config) {
 		.userDataToken = config.storageId.token.toStdString(),
 		.debug = OptionWebviewDebugEnabled.value(),
 		.safe = config.safe,
+		.allowThirdPartyCookies = config.allowThirdPartyCookies,
 		.mode = config.mode,
 		.windowStyle = config.windowStyle,
 		.windowMargins = config.windowMargins,

--- a/webview/webview_embed.h
+++ b/webview/webview_embed.h
@@ -42,6 +42,7 @@ struct WindowConfig {
 	StorageId storageId;
 	QString dataProtocolOverride;
 	bool safe = false;
+	bool allowThirdPartyCookies = false;
 	WindowMode mode = WindowMode::Embedded;
 	WindowStyle windowStyle = WindowStyle::Default;
 	QMargins windowMargins;

--- a/webview/webview_interface.h
+++ b/webview/webview_interface.h
@@ -167,6 +167,7 @@ struct Config {
 	std::string userDataToken;
 	bool debug = false;
 	bool safe = false;
+	bool allowThirdPartyCookies = false;
 	WindowMode mode = WindowMode::Embedded;
 	WindowStyle windowStyle = WindowStyle::Default;
 	QMargins windowMargins;


### PR DESCRIPTION
## Summary

- add an opt-in `allowThirdPartyCookies` window setting
- forward the setting across the Linux helper D-Bus boundary
- apply WebKit's `ACCEPT_ALWAYS` policy to WebKitGTK 6 and 4.x cookie managers

## Testing

- generated and inspected the D-Bus C interface from the updated XML
- compiled, linked, and ran strict API probes against Ubuntu 24.04 WebKitGTK 6.0 and 4.1
- passed XML and whitespace validation