### PR TITLE
Fix WebView dialog size feedback loop on Wayland

### DIFF
--- a/webview/webview_dialog.cpp
+++ b/webview/webview_dialog.cpp
@@ -26,6 +26,8 @@
 #include <QtCore/QPointer>
 #include <QtCore/QCoreApplication>
 
+#include "rpl/take.h"
+
 #include <memory>
 
 namespace Webview {
@@ -242,7 +244,7 @@ PopupResult ShowBlockingPopup(PopupArgs &&args) {
 		container->resizeToWidth(st::boxWideWidth);
 
 		container->heightValue(
-		) | rpl::on_next([=](int height) {
+		) | rpl::take(1) | rpl::on_next([=](int height) {
 			raw->setInnerSize({ st::boxWideWidth, titleHeight + height });
 		}, container->lifetime());
 
@@ -469,7 +471,7 @@ void ShowPopupAsync(
 		container->resizeToWidth(st::boxWideWidth);
 
 		container->heightValue(
-		) | rpl::on_next([=](int height) {
+		) | rpl::take(1) | rpl::on_next([=](int height) {
 			raw->setInnerSize({ st::boxWideWidth, titleHeight + height });
 		}, container->lifetime());
 


### PR DESCRIPTION
## Summary

- consume only the initial `VerticalLayout::heightValue()` emission when sizing WebView dialogs
- prevent dialog content size changes from feeding back into the native window size

## Problem

For WebView confirmation dialogs on Wayland, `setInnerSize()` can trigger another layout height update. Subscribing to every `heightValue()` emission feeds that update back into `setInnerSize()`, creating a positive size loop that rapidly stretches the dialog far beyond the monitor bounds.

The content height is needed for the initial dialog size only. Taking the first emission breaks the feedback loop for both blocking and asynchronous popup paths.

## Validation

- built and tested through Telegram Desktop 7.0.6 on Arch Linux
- reproduced with a BotFather Mini App confirmation dialog under Hyprland 0.56.1
- before: the dialog height grew from 2,958 px to 12,974 px
- after: the same dialog remained stable at 355 x 142 px for repeated observations
- confirmed the patch applies cleanly to the current `master` branch

